### PR TITLE
Update mmpose.cpp

### DIFF
--- a/mmpose/CMakeLists.txt
+++ b/mmpose/CMakeLists.txt
@@ -5,6 +5,13 @@ project(mmpose_trt)
 set(CMAKE_CXX_STANDARD 14)
 
 # CUDA
+SET(CMAKE_CUDA_COMPILER /usr/local/cuda-11.1/bin/nvcc)
+SET(CUDA_TOOLKIT_ROOT_DIR /usr/local/cuda-11.1)
+SET(TENSORRT_INCLUDE_DIR "/home/vid/tensorrt/TensorRT-7.2.3.4/include")
+SET(TENSORRT_LIBRARY_INFER "/home/vid/tensorrt/TensorRT-7.2.3.4/lib/libnvinfer.so")
+SET(TENSORRT_LIBRARY_ONNXPARSER "/home/vid/tensorrt/TensorRT-7.2.3.4/lib/libnvonnxparser.so")
+
+
 find_package(CUDA REQUIRED)
 message(STATUS "Find CUDA include at ${CUDA_INCLUDE_DIRS}")
 message(STATUS "Find CUDA libraries: ${CUDA_LIBRARIES}")
@@ -34,6 +41,8 @@ set(YAML_LIB_DIR ../includes/yaml-cpp/libs)
 
 include_directories(${CUDA_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${OpenCV_INCLUDE_DIRS} ${COMMON_INCLUDE} ${YAML_INCLUDE})
 link_directories(${YAML_LIB_DIR})
+
+# SET(NVPARSERS /home/vid/tensorrt/TensorRT-7.2.3.4/targets/x86_64-linux-gnu/lib/libnvparsers.so)
 
 add_executable(mmpose_trt main.cpp mmpose.cpp ../includes/common/model.cpp ../includes/common/common.cpp)
 target_link_libraries(mmpose_trt ${OpenCV_LIBRARIES} ${CUDA_LIBRARIES} ${TENSORRT_LIBRARY} yaml-cpp)

--- a/mmpose/mmpose.cpp
+++ b/mmpose/mmpose.cpp
@@ -97,7 +97,8 @@ void mmpose::EngineInference(const std::vector<std::string> &image_list, const i
             // DMA the input to the GPU,  execute the batch asynchronously, and DMA it back:
             std::cout << "host2device" << std::endl;
             cudaMemcpyAsync(buffers[0], curInput.data(), bufferSize[0], cudaMemcpyHostToDevice, stream);
-
+            cudaStreamSynchronize(stream);
+            
             // do inference
             std::cout << "execute" << std::endl;
             auto t_start = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
I ran into an error on Windows. 
During execution we call
`cudaMemcpyAsync(buffers[0], curInput.data(), bufferSize[0], cudaMemcpyHostToDevice, stream); `
and `curInput.data()` does not have ehough time to load into GPU memory. In result 
`context->execute(BATCH_SIZE, buffers); `
executes on previous image.

`cudaStreamSynchronize(stream);` 
solved this problem.